### PR TITLE
Add tests for parse_tags and dependency config

### DIFF
--- a/data_processing/parse_sevenfifty.py
+++ b/data_processing/parse_sevenfifty.py
@@ -1,4 +1,3 @@
-import pandas as pd
 import json
 import os
 
@@ -14,6 +13,8 @@ def parse_tags(tag):
 
 
 def parse_data(input_file, output_file):
+    import pandas as pd
+
     # Read the input file (XLSX)
     df = pd.read_excel(input_file)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pandas
+pytest

--- a/tests/test_parse_tags.py
+++ b/tests/test_parse_tags.py
@@ -1,0 +1,47 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import pytest
+from data_processing.parse_sevenfifty import parse_tags
+
+
+@pytest.mark.parametrize(
+  "tag,expected",
+  [
+    (
+      "CK",
+      {
+        "chattanooga": True,
+        "knoxville": True,
+        "memphis": False,
+        "nashville": False,
+        "broad_market": True,
+      },
+    ),
+    (
+      "MNX",
+      {
+        "chattanooga": False,
+        "knoxville": False,
+        "memphis": True,
+        "nashville": True,
+        "broad_market": False,
+      },
+    ),
+  ],
+)
+def test_parse_tags_valid(tag, expected):
+  assert parse_tags(tag) == expected
+
+
+@pytest.mark.parametrize("tag", ["Unknown", ""])
+def test_parse_tags_unknown(tag):
+  result = parse_tags(tag)
+  assert result == {
+    "chattanooga": False,
+    "knoxville": False,
+    "memphis": False,
+    "nashville": False,
+    "broad_market": True,
+  }
+
+


### PR DESCRIPTION
## Summary
- add `pytest` and `pandas` requirement file
- move pandas import inside `parse_data`
- add tests for `parse_tags`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68442c67cc9c8323b71623ae824d84f8